### PR TITLE
Add config for NVD API URL

### DIFF
--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckKeys.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckKeys.scala
@@ -106,6 +106,7 @@ trait DependencyCheckKeys {
 
 	// Advanced configuration
 	lazy val dependencyCheckNvdApiKey = settingKey[Option[String]]("The API key used when connecting to the NVD API.")
+	lazy val dependencyCheckNvdApiDatafeedUrl = settingKey[Option[String]]("The URL for the NVD API Data feed that can be generated using Vulnz")
 	lazy val dependencyCheckNvdApiUser = settingKey[Option[String]]("The username used when connecting to the NVD API.")
 	lazy val dependencyCheckNvdApiPassword = settingKey[Option[String]]("The password used when connecting to the NVD API.")
 	lazy val dependencyCheckNvdApiStartYear = settingKey[Option[Int]]("The first year of NVD CVE data to download from the NVD API.")

--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckPlugin.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckPlugin.scala
@@ -7,7 +7,7 @@ import org.owasp.dependencycheck.data.nexus.MavenArtifact
 import org.owasp.dependencycheck.dependency.naming.{GenericIdentifier, Identifier, PurlIdentifier}
 import org.owasp.dependencycheck.dependency.{Confidence, Dependency, EvidenceType}
 import org.owasp.dependencycheck.exception.ExceptionCollection
-import org.owasp.dependencycheck.utils.{Settings, SeverityUtil}
+import org.owasp.dependencycheck.utils.{Downloader, Settings, SeverityUtil}
 import org.owasp.dependencycheck.utils.Settings.KEYS.*
 import sbt.Keys.*
 import sbt.plugins.JvmPlugin
@@ -643,6 +643,7 @@ object DependencyCheckPlugin extends sbt.AutoPlugin {
     val oldClassLoader = Thread.currentThread().getContextClassLoader
     val newClassLoader = classOf[Engine].getClassLoader
     val engine: Engine = new Engine(newClassLoader, settings)
+    Downloader.getInstance.configure(settings)
     try {
       Thread.currentThread().setContextClassLoader(newClassLoader)
       fn(engine)

--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckPlugin.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckPlugin.scala
@@ -127,6 +127,7 @@ object DependencyCheckPlugin extends sbt.AutoPlugin {
 
     // Advanced configuration
     dependencyCheckNvdApiKey := None,
+    dependencyCheckNvdApiDatafeedUrl := None,
     dependencyCheckNvdApiUser := None,
     dependencyCheckNvdApiPassword := None,
     dependencyCheckNvdApiStartYear := None,
@@ -304,6 +305,7 @@ object DependencyCheckPlugin extends sbt.AutoPlugin {
 
     // Advanced Configuration
     setStringSetting(NVD_API_KEY, dependencyCheckNvdApiKey.value)
+    setStringSetting(NVD_API_DATAFEED_URL, dependencyCheckNvdApiDatafeedUrl.value)
     setStringSetting(NVD_API_DATAFEED_USER, dependencyCheckNvdApiUser.value)
     setStringSetting(NVD_API_DATAFEED_PASSWORD, dependencyCheckNvdApiPassword.value)
     setIntSetting(NVD_API_DATAFEED_START_YEAR, dependencyCheckNvdApiStartYear.value.map(_.max(2002)))


### PR DESCRIPTION
Howdy,

First off, thank you so much for raising a fork that uses `12.1.0`. I've been pulling my hair out trying to find a replacement to the original plugin (Trivy has accuracy issues and the POMs SBT projects build don't seem to be complete enough to run the Maven plugin over them).

One of the things you're missing however is the ability to specify the datafeed URL. [Vulnz](https://github.com/jeremylong/open-vulnerability-cli) is a tool also written by Jeremy Long that is able to download the NVD data independently so it can be cached. A lot of people use it for various reasons. All this plugin should need is a setting to help configure it, however I haven't touched Scala/SBT in 10 years now.